### PR TITLE
Use {load, store}Capability permissions

### DIFF
--- a/src/main/scala/riscv/plugins/cheri/Capability.scala
+++ b/src/main/scala/riscv/plugins/cheri/Capability.scala
@@ -3,6 +3,8 @@ package riscv.plugins.cheri
 import spinal.core._
 
 trait Permissions {
+  // https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf Table 3.1 p. 75
+  // Some permissions are missing
   def execute: Bool
   def load: Bool
   def store: Bool
@@ -71,6 +73,7 @@ case class PackedPermissions() extends Bundle with Permissions {
 }
 
 case class ObjectType(implicit context: Context) extends Bundle {
+  // https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf Table 3.2 p. 78
   val value = UInt(context.otypeLen bits)
 
   def extendedValue: UInt = {
@@ -198,18 +201,18 @@ object RegCapability {
 }
 
 case class MemPermissions() extends Bundle with Permissions {
-  private val padding1 = B"0"
+  private val padding1 = B"0" // reserved: global
   override val execute = Bool()
   override val load = Bool()
   override val store = Bool()
   override val loadCapability = Bool()
   override val storeCapability = Bool()
-  private val padding2 = B"0"
+  private val padding2 = B"0" // reserved: storeLocalCapability
   override val seal = Bool()
   override val cinvoke = Bool()
   override val unseal = Bool()
   override val accessSystemRegisters = Bool()
-  private val padding3 = B"0000"
+  private val padding3 = B"0000" // reserved: setCID + unused bits
 
   assert(getBitsWidth == 15)
 }

--- a/src/main/scala/riscv/plugins/cheri/Ccsr.scala
+++ b/src/main/scala/riscv/plugins/cheri/Ccsr.scala
@@ -4,13 +4,15 @@ import riscv._
 
 import spinal.core._
 
+// Control and Status Registers
+// https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf §5.3.4 p. 147
 class Ccsr extends Plugin[Pipeline] {
 
   override def setup(): Unit = {
     val csrFile = pipeline.service[CsrService]
 
     csrFile.registerCsr(
-      0xbc0,
+      0xbc0, // Machine capability control and status register (mccsr)
       new Csr {
         val cause = Reg(UInt(5 bits)).init(0)
         val capIdx = Reg(UInt(6 bits)).init(0)

--- a/src/main/scala/riscv/plugins/cheri/Cheri.scala
+++ b/src/main/scala/riscv/plugins/cheri/Cheri.scala
@@ -5,6 +5,8 @@ import riscv._
 import spinal.core._
 
 object Opcodes {
+  // https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf CHERI-RISC-V instructions p. 284
+  // Possibly some instructions are missing
   val CGetPerm = M"111111100000-----000-----1011011"
   val CGetType = M"111111100001-----000-----1011011"
   val CGetBase = M"111111100010-----000-----1011011"
@@ -121,6 +123,7 @@ object InstructionType {
 }
 
 object ScrIndex {
+  // https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf Table 5.3 p. 150
   val PCC = 0
   val DDC = 1
 
@@ -147,6 +150,7 @@ object TrapCause {
 sealed abstract class ExceptionCause(val code: Int)
 
 object ExceptionCause {
+  // https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf Table 3.3 p. 109
   case object None extends ExceptionCause(0x00)
   case object LengthViolation extends ExceptionCause(0x01)
   case object TagViolation extends ExceptionCause(0x02)
@@ -156,7 +160,7 @@ object ExceptionCause {
   case object ReturnTrap extends ExceptionCause(0x06)
   case object TrustedSystemStackOverflow extends ExceptionCause(0x07)
   case object SoftwareDefinedPermissionViolation extends ExceptionCause(0x08)
-  case object MmuProhibitsStoreCapability extends ExceptionCause(0x09)
+  case object MmuProhibitsStoreCapability extends ExceptionCause(0x09) // Deprecated, only for CHERI-MIPS ?
   case object BoundsCannotBeRepresentedExactly extends ExceptionCause(0x0a)
   case object GlobalViolation extends ExceptionCause(0x10)
   case object PermitExecuteViolation extends ExceptionCause(0x11)

--- a/src/main/scala/riscv/plugins/cheri/Context.scala
+++ b/src/main/scala/riscv/plugins/cheri/Context.scala
@@ -3,8 +3,8 @@ package riscv.plugins.cheri
 import riscv._
 
 case class Context(pipeline: Pipeline)(implicit val config: Config) {
-  val clen = 4 * config.xlen
-  val otypeLen = 12
-  val maxOtype = (1 << otypeLen) - 17
+  val clen = 4 * config.xlen // capability length
+  val otypeLen = 12 // bit width reserved for the Object Type field
+  val maxOtype = (1 << otypeLen) - 17 // value used to know whether a capability is sealed, cf https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf p. 78
   val data = new GlobalPipelineData(pipeline)(this)
 }

--- a/src/main/scala/riscv/plugins/cheri/ScrFile.scala
+++ b/src/main/scala/riscv/plugins/cheri/ScrFile.scala
@@ -6,11 +6,13 @@ import spinal.lib._
 
 import scala.collection.mutable
 
+// Special capability registers file
+// https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf §5.3.5 p. 149
 class ScrFile(scrStage: Stage)(implicit context: Context) extends Plugin[Pipeline] with ScrService {
   private class ScrComponent extends Component {
     val io = master(ScrIo())
 
-    // We treat DDC specially to make getDdc easier to implement. This should probably bd done using
+    // We treat DDC specially to make getDdc easier to implement. This should probably be done using
     // registerScr like all other SCRs to make getScr also work for DDC.
     val ddc = out(Reg(RegCapability()).init(RegCapability.Root))
   }

--- a/src/main/scala/riscv/plugins/cheri/Sealing.scala
+++ b/src/main/scala/riscv/plugins/cheri/Sealing.scala
@@ -68,6 +68,8 @@ class Sealing(stage: Stage)(implicit context: Context) extends Plugin[Pipeline] 
         arbitration.rs2Needed := True
 
         when(!arbitration.isStalled) {
+          // Exception priority
+          // https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf Table 3.4 p. 110
           when(!cs1.tag) {
             except(ExceptionCause.TagViolation, cs1Idx)
           } elsewhen (!cs2.tag) {
@@ -101,6 +103,8 @@ class Sealing(stage: Stage)(implicit context: Context) extends Plugin[Pipeline] 
         arbitration.rs2Needed := True
 
         when(!arbitration.isStalled) {
+          // Exception priority
+          // https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf Table 3.4 p. 110
           when(!cs1.tag) {
             except(ExceptionCause.TagViolation, cs1Idx)
           } elsewhen (!cs2.tag) {
@@ -137,6 +141,8 @@ class Sealing(stage: Stage)(implicit context: Context) extends Plugin[Pipeline] 
           val target = cs1.address
           target.lsb := False
 
+          // Exception priority
+          // https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-951.pdf Table 3.4 p. 110
           when(!cs1.tag) {
             except(ExceptionCause.TagViolation, cs1Idx)
           } elsewhen (!cs2.tag) {

--- a/src/main/scala/riscv/plugins/cheri/tests/LsuCap.S
+++ b/src/main/scala/riscv/plugins/cheri/tests/LsuCap.S
@@ -77,6 +77,20 @@ RVTEST_CODE_BEGIN
         EXPECT_EXCEPTION(CAUSE_SEAL_VIOLATION, 1, LC.cap ROOT, (c1))
         EXPECT_EXCEPTION(CAUSE_SEAL_VIOLATION, 1, SC.cap ROOT, (c1))
 
+    TEST_CASE_FREE(16)
+        la t0, scratch
+        CSetAddr c1, ROOT, t0
+        SC.cap ROOT, (c1)
+        li t0, ~(1 << PERM_PERMIT_LOAD_CAPABILITY)
+        CAndPerm c1, c1, t0
+        EXPECT_EXCEPTION(CAUSE_PERMIT_LOAD_CAPABILITY_VIOLATION, 1, LC.cap c2, (c1))
+
+    TEST_CASE_FREE(17)
+        la t0, scratch
+        CSetAddr c1, ROOT, t0
+        li t0, ~(1 << PERM_PERMIT_STORE_CAPABILITY)
+        CAndPerm c1, c1, t0
+        EXPECT_EXCEPTION(CAUSE_PERMIT_STORE_CAPABILITY_VIOLATION, 1, SC.cap ROOT, (c1))
 
     TEST_PASSFAIL
 

--- a/src/main/scala/riscv/plugins/cheri/tests/Pcc.S
+++ b/src/main/scala/riscv/plugins/cheri/tests/Pcc.S
@@ -39,7 +39,7 @@ RVTEST_CODE_BEGIN
         CClearTag c1, c1
         EXPECT_EXCEPTION(CAUSE_TAG_VIOLATION, 1, CJALR c1)
 
-    # Overflow execution out of capabiliy range (4 bytes)
+    # Overflow execution out of capability range (4 bytes)
     TEST_CASE_START(5)
         la t0, 1f
         CSetBounds c1, ROOT, t0
@@ -49,7 +49,7 @@ RVTEST_CODE_BEGIN
     2:
         EXPECT_EXCEPTION(CAUSE_LENGTH_VIOLATION, CAP_IDX_PCC, 1: j fail)
 
-    # Overflow execution out of capabiliy range (1 byte)
+    # Overflow execution out of capability range (1 byte)
     TEST_CASE_START(6)
         la t0, 1f
         addi t0, t0, 3

--- a/src/main/scala/riscv/plugins/cheri/tests/README.md
+++ b/src/main/scala/riscv/plugins/cheri/tests/README.md
@@ -1,0 +1,14 @@
+# README
+
+_Disclaimer: the information below might not be entirely accurate, any suggestion and improvement is welcome._
+
+In order to run the tests in this folder, a CHERI-aware compiler is needed. The easiest way to install one is through using [`cheribuild`](https://github.com/CTSRD-CHERI/cheribuild) and then running the command `./cheribuild llvm-native`. <!-- Maybe ./cheribuild newlib-baremetal-riscv32-hybrid ? -->
+
+The file `Makefile.include` must then be modified so that `CC` points to the installed compiler. 
+By default, this should be `~\cheri\output\sdk\bin\clang`.
+
+Additionally, the RISC-V toolchain mentioned [here](https://github.com/proteus-core/proteus#building-software) is also required. <!-- Why though ? -->
+Make sure it is present in your `PATH`.
+
+The tests can then finally be run from the root directory using `make -C tests/ CUSTOM_TESTS_DIR=../src/main/scala/riscv/plugins/cheri/tests/`.
+The files `Pcc.S` and `Scr.S` currently fail to compile for an unknown reason.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,7 +8,7 @@ SIM_EXE = $(SIM_DIR)/build/sim
 CORE ?= riscv.CoreExtMem
 BUILD_CORE ?= 1
 
-RISCV_PREFIX ?= riscv64-unknown-elf
+RISCV_PREFIX ?= riscv32-unknown-elf
 CC = $(RISCV_PREFIX)-gcc
 LD = $(RISCV_PREFIX)-gcc
 OBJCOPY = $(RISCV_PREFIX)-objcopy


### PR DESCRIPTION
- Fixes #1.
  See the additional checks in `src/main/scala/riscv/plugins/cheri/Lsu.scala`.
- Added test cases to check the changes in `src/main/scala/riscv/plugins/cheri/tests/LsuCap.S`.
  Confirmed that the tests fail before the changes and pass afterwards.
- Added various comments and pointers to the CHERI specification in multiple places.
- Added a short `README` to explain how to run the CHERI tests `src/main/scala/riscv/plugins/cheri/tests/README.md`.
 