### PR TITLE
Fix invalid AXI write data valid when no AXI write is active

### DIFF
--- a/src/main/scala/riscv/MemBus.scala
+++ b/src/main/scala/riscv/MemBus.scala
@@ -88,7 +88,7 @@ case class MemBus(val config: MemBusConfig, val idWidth: BitCount)
     axi4Bus.sharedCmd.id := cmd.id
     cmd.ready := axi4Bus.sharedCmd.ready
 
-    axi4Bus.writeData.valid := cmd.valid
+    axi4Bus.writeData.valid := cmd.write && cmd.valid
     axi4Bus.writeData.data := cmd.wdata.asBits
     axi4Bus.writeData.strb := cmd.wmask
     axi4Bus.writeData.last := True


### PR DESCRIPTION
The W channel (of the dbus) gets a valid even when AW channel is not active. This violates the AXI spec and this PR fixes it.