### PR TITLE
Fixed a bug where MULH would not work as expected.

### DIFF
--- a/src/main/scala/riscv/plugins/MulDiv.scala
+++ b/src/main/scala/riscv/plugins/MulDiv.scala
@@ -157,11 +157,13 @@ class MulDiv(exeStages: Set[Stage]) extends Plugin[Pipeline] {
             val partialSum = UInt(config.xlen + 1 bits)
 
             when(product.lsb) {
-              when(value(Data.MUL_HIGH) && rs1.asSInt < 0 && rs2.asSInt < 0 &&
-                value(Data.MULDIV_RS2_SIGNED) && value(Data.MULDIV_RS1_SIGNED)) {
+              when(
+                value(Data.MUL_HIGH) && rs1.asSInt < 0 && rs2.asSInt < 0 &&
+                  value(Data.MULDIV_RS2_SIGNED) && value(Data.MULDIV_RS1_SIGNED)
+              ) {
                 partialSum := extendedProductH + multiplicand(31 downto 0)
-              } elsewhen(step.value === 31 && rs1.asSInt<0
-                && value(Data.MULDIV_RS2_SIGNED) && value(Data.MULDIV_RS1_SIGNED)){
+              } elsewhen (step.value === 31 && rs1.asSInt < 0
+                && value(Data.MULDIV_RS2_SIGNED) && value(Data.MULDIV_RS1_SIGNED)) {
                 partialSum := extendedProductH + multiplicand(31 downto 0)
               } otherwise {
                 partialSum := extendedProductH + multiplicand

--- a/src/main/scala/riscv/plugins/MulDiv.scala
+++ b/src/main/scala/riscv/plugins/MulDiv.scala
@@ -157,7 +157,15 @@ class MulDiv(exeStages: Set[Stage]) extends Plugin[Pipeline] {
             val partialSum = UInt(config.xlen + 1 bits)
 
             when(product.lsb) {
-              partialSum := extendedProductH + multiplicand
+              when(value(Data.MUL_HIGH) && rs1.asSInt < 0 && rs2.asSInt < 0 &&
+                value(Data.MULDIV_RS2_SIGNED) && value(Data.MULDIV_RS1_SIGNED)) {
+                partialSum := extendedProductH + multiplicand(31 downto 0)
+              } elsewhen(step.value === 31 && rs1.asSInt<0
+                && value(Data.MULDIV_RS2_SIGNED) && value(Data.MULDIV_RS1_SIGNED)){
+                partialSum := extendedProductH + multiplicand(31 downto 0)
+              } otherwise {
+                partialSum := extendedProductH + multiplicand
+              }
             } otherwise {
               partialSum := extendedProductH
             }


### PR DESCRIPTION
This issue affects the MULH instruction when multiplying large negative numbers. The issue is that the whole 33-bit multiplicant gets copied, which is incorrect while using negative numbers.

This fix allows large negative numbers to be multiplied by each other in a correct manner. By not copying the whole 33 bit multiplicant but limiting it to 32 bits the issue is resolved. 

This change is made to the MulDiv.scala file in the plugins folder. 

The RISC-V tests ran with `make -C tests CORE=riscv.CoreExtMem` still returns `All tests passed`

This issue was not caught by the RISC-V tests because it only affects these high, negative numbers, which are not tested in the test suite. 
