### PR TITLE
Fix inconsistency between write data and write mask

### DIFF
--- a/sim/main.cpp
+++ b/sim/main.cpp
@@ -113,31 +113,23 @@ private:
         ensureEnoughMemory(address);
 
         auto bitMask = Word{0};
-        unsigned extra = 0;
-        for (unsigned i = 0; i < MEMBUS_WORDS; ++i) {
-            if (mask & (1 << (4 * i + 0))) {
-                extra = i;
-                bitMask |= 0x000000ff;
-            }
-            if (mask & (1 << (4 * i + 1))) {
-                extra = i;
-                bitMask |= 0x0000ff00;
-            }
-            if (mask & (1 << (4 * i + 2))) {
-                extra = i;
-                bitMask |= 0x00ff0000;
-            }
-            if (mask & (1 << (4 * i + 3))) {
-                extra = i;
-                bitMask |= 0xff000000;
-            }
-        }
-
         auto baseAddress = (address >> MEMBUS_OFFSET) << (MEMBUS_OFFSET - 2);
 
-        auto& memoryValue = memory_[baseAddress + extra];
-        memoryValue &= ~bitMask;
-        memoryValue |= value[0] & bitMask;
+        for (unsigned i = 0; i < MEMBUS_WORDS; ++i) {
+            bitMask = 0;
+
+            for (int byte = 0; byte < 4; ++byte) {
+                if (mask & (1 << (4 * i + byte))) {
+                    bitMask |= 0xff << (8 * byte);
+                }
+            }
+
+            if (bitMask != 0) {
+                auto& memoryValue = memory_[baseAddress + i];
+                memoryValue &= ~bitMask;
+                memoryValue |= value[i] & bitMask;
+            }
+        }
     }
 
     void ensureEnoughMemory(Address address)

--- a/src/main/scala/riscv/plugins/memory/Lsu.scala
+++ b/src/main/scala/riscv/plugins/memory/Lsu.scala
@@ -429,7 +429,10 @@ class Lsu(addressStages: Set[Stage], loadStages: Seq[Stage], storeStage: Stage)
             }
           }
 
-          val accepted = dbusCtrl.write(busAddress, data.resized, mask)
+          // Position the data within the cache line
+          val cacheLine = data << (busAddress(addressOffset downto 0) << 3)
+
+          val accepted = dbusCtrl.write(busAddress, cacheLine.resized, mask)
           arbitration.isReady := accepted
 
           formal.lsuOnStore(storeStage, busAddress, mask, data)


### PR DESCRIPTION
Fixed an inconsistency between the write data and write mask for cache lines larger than 1 word. Previously, the write data would always be positioned in word 0 of the cache line, causing problems when writing to external memory on FPGA.
The SW simulation of external memory was also updated to take this into account.