### PR TITLE
Updated PrefetchService and cache optimizations

### DIFF
--- a/src/main/scala/riscv/Core.scala
+++ b/src/main/scala/riscv/Core.scala
@@ -57,7 +57,7 @@ object createStaticPipeline {
         new PcManager(0x80000000L),
         new BranchTargetPredictor(pipeline.fetch, pipeline.execute, 8, conf.xlen),
         prefetcher,
-        new Cache(sets = 2, ways = 2, backbone.filterIBus, Some(prefetcher)),
+        new Cache(sets = 2, ways = 2, backbone.filterIBus, Some(prefetcher), maxPrefetches = 2),
         new Cache(sets = 8, ways = 2, backbone.filterDBus, cacheable = (_ >= 0x80000000L)),
         new CsrFile(pipeline.writeback, pipeline.writeback), // TODO: ugly
         new Timers,
@@ -256,7 +256,13 @@ object createDynamicPipeline {
           conf.xlen
         ),
         prefetcher,
-        new Cache(sets = 2, ways = 2, pipeline.backbone.filterIBus, Some(prefetcher)),
+        new Cache(
+          sets = 2,
+          ways = 2,
+          pipeline.backbone.filterIBus,
+          Some(prefetcher),
+          maxPrefetches = 2
+        ),
         new Cache(
           sets = 8,
           ways = 2,

--- a/src/main/scala/riscv/Services.scala
+++ b/src/main/scala/riscv/Services.scala
@@ -315,15 +315,15 @@ trait PrefetchService {
 
   /** Inform the prefetcher of a load request
     */
-  def notifyLoadRequest(address: UInt): Unit = {}
+  def notifyLoadRequest(address: UInt): Unit
 
   /** Inform the prefetcher of a load response returning from memory
     */
-  def notifyLoadResponseFromMemory(address: UInt, data: UInt): Unit = {}
+  def notifyLoadResponseFromMemory(address: UInt, data: UInt): Unit
 
   /** Inform the prefetcher of a prefetch response returning from memory
     */
-  def notifyPrefetchResponseFromMemory(address: UInt, data: UInt): Unit = {}
+  def notifyPrefetchResponseFromMemory(address: UInt, data: UInt): Unit
 
   /** Check if the prefetcher has a prefetch target ready
     */

--- a/src/main/scala/riscv/Services.scala
+++ b/src/main/scala/riscv/Services.scala
@@ -312,8 +312,26 @@ trait BranchTargetPredictorService {
 }
 
 trait PrefetchService {
-  def updatePrefetcherState(address: UInt, insignificantBits: Int): Unit
-  def getPrefetchTarget: UInt
+
+  /** Inform the prefetcher of a load request
+    */
+  def notifyLoadRequest(address: UInt): Unit = {}
+
+  /** Inform the prefetcher of a load response returning from memory
+    */
+  def notifyLoadResponseFromMemory(address: UInt, data: UInt): Unit = {}
+
+  /** Inform the prefetcher of a prefetch response returning from memory
+    */
+  def notifyPrefetchResponseFromMemory(address: UInt, data: UInt): Unit = {}
+
+  /** Check if the prefetcher has a prefetch target ready
+    */
+  def hasPrefetchTarget: Bool
+
+  /** Get the next prefetch target from the prefetcher
+    */
+  def getNextPrefetchTarget: UInt
 }
 
 trait TrapService {

--- a/src/main/scala/riscv/plugins/Cache.scala
+++ b/src/main/scala/riscv/plugins/Cache.scala
@@ -119,7 +119,7 @@ class Cache(
         val storeInvalidated: Bool = Bool()
         val pending: Bool = Bool()
         val isPrefetch: Bool = Bool()
-        val internalIds: UInt = UInt(Math.pow(2, internal.config.idWidth).toInt bits)
+        val internalIds: Bits = Bits(1 << internal.config.idWidth bits)
       }
 
       private val outstandingLoads = Vec.fill(maxId + 1)(RegInit(OutstandingTracker().getZero))
@@ -248,7 +248,7 @@ class Cache(
               outstandingLoads(externalId).address := internal.cmd.address
               outstandingLoads(externalId).pending := True
               outstandingLoads(externalId).isPrefetch := False
-              outstandingLoads(externalId).internalIds := U(0).resized
+              outstandingLoads(externalId).internalIds := B(0).resized
               outstandingLoads(externalId).internalIds(internal.cmd.id) := True
               externalId := externalId + 1
             }
@@ -256,7 +256,7 @@ class Cache(
             outstandingLoads(externalId).address := internal.cmd.address
             outstandingLoads(externalId).pending := True
             outstandingLoads(externalId).isPrefetch := False
-            outstandingLoads(externalId).internalIds := U(0).resized
+            outstandingLoads(externalId).internalIds := B(0).resized
             outstandingLoads(externalId).internalIds(internal.cmd.id) := True
             externalId := externalId + 1
           }
@@ -328,7 +328,7 @@ class Cache(
 
                 outstandingLoads(externalId).address := prefetchAddress
                 outstandingLoads(externalId).pending := True
-                outstandingLoads(externalId).internalIds := U(0).resized
+                outstandingLoads(externalId).internalIds := B(0).resized
                 outstandingLoads(externalId).isPrefetch := True
 
                 when(!external.cmd.ready) {

--- a/src/main/scala/riscv/plugins/memory/DynamicMemoryBackbone.scala
+++ b/src/main/scala/riscv/plugins/memory/DynamicMemoryBackbone.scala
@@ -151,6 +151,7 @@ class DynamicMemoryBackbone(stageCount: Int)(implicit config: Config)
           currentlySendingIndex.setIdle()
           cmdBuffer.setIdle()
           when(!cmdBuffer.write) {
+            nextId.increment()
             busId2StageIndex(nextId).stageIndex := currentlySendingIndex.payload
             when(!sameCycleReturn) {
               busId2StageIndex(nextId).cmdSent := True
@@ -159,7 +160,6 @@ class DynamicMemoryBackbone(stageCount: Int)(implicit config: Config)
             currentlyInserting.valid := True
             currentlyInserting.payload.stageIndex := currentlySendingIndex.payload
           }
-          nextId.increment()
         }
       }
 
@@ -179,6 +179,7 @@ class DynamicMemoryBackbone(stageCount: Int)(implicit config: Config)
               currentlySendingIndex.setIdle()
               cmdBuffer.setIdle()
               when(!cmd.write) {
+                nextId.increment()
                 busId2StageIndex(nextId).stageIndex := U(index).resized
                 when(!sameCycleReturn) {
                   busId2StageIndex(nextId).cmdSent := True
@@ -187,7 +188,6 @@ class DynamicMemoryBackbone(stageCount: Int)(implicit config: Config)
                 currentlyInserting.valid := True
                 currentlyInserting.payload.stageIndex := index
               }
-              nextId.increment()
             } otherwise {
               movingToCmdBuffer.push(index)
               cmdBuffer.push(unifiedInternalDBus.cmd)

--- a/src/main/scala/riscv/plugins/memory/SequentialInstructionPrefetcher.scala
+++ b/src/main/scala/riscv/plugins/memory/SequentialInstructionPrefetcher.scala
@@ -23,6 +23,10 @@ class SequentialInstructionPrefetcher(implicit config: Config) extends Plugin wi
     }
   }
 
+  override def notifyLoadResponseFromMemory(address: UInt, data: UInt): Unit = {}
+
+  override def notifyPrefetchResponseFromMemory(address: UInt, data: UInt): Unit = {}
+
   override def getNextPrefetchTarget: UInt = {
     hasNewTarget := False
     ((currentAddress >> insignificantBits) + 1) << insignificantBits


### PR DESCRIPTION
- The cache now supports multiple simultaneous prefetches with a configurable upper limit
- PrefetchService has been updated with support for memory-dependent prefetchers
- The cache now assigns the external bus ids to accommodate for prefetches
- Changed cache hits and misses count to be more accurate
- Allow the cache to forward load responses to multiple internal pending loads
- Changed the dynamic memory backbone to not increase the id on writes