### PR TITLE
Superscalar PSF and ROB Flush system

### DIFF
--- a/src/main/scala/riscv/Config.scala
+++ b/src/main/scala/riscv/Config.scala
@@ -28,13 +28,13 @@ class Config(val baseIsa: BaseIsa, val debug: Boolean = true, val stlSpec: Boole
 
   def memBusWidth: Int = 128
 
-  def robEntries: Int = 32
+  def robEntries: Int = 8
 
-  def parallelAlus: Int = 8
+  def parallelAlus: Int = 2
 
-  def parallelMulDivs: Int = 2
+  def parallelMulDivs: Int = 1
 
-  def parallelLoads: Int = 3
+  def parallelLoads: Int = 1
 
   def addressBasedPsf: Boolean = true
 

--- a/src/main/scala/riscv/Services.scala
+++ b/src/main/scala/riscv/Services.scala
@@ -142,6 +142,10 @@ object LsuAccessWidth extends SpinalEnum {
   val B, H, W = newElement() // TODO: this could mess with memory disambiguation predictors
 }
 
+object PsfState extends SpinalEnum {
+  val NONE, PREDICTION, WARNING, MISS = newElement()
+}
+
 trait LsuAddressTranslator {
 
   /** This method can be used to change the address used by the LSU. The input address is the one
@@ -222,9 +226,9 @@ trait LsuService {
 
   def address(stage: Stage): UInt
 
-  def psfMisspeculation(bundle: Bundle with DynBundleAccess[PipelineData[Data]]): Bool
+  def psfState(bundle: Bundle with DynBundleAccess[PipelineData[Data]]): SpinalEnumCraft[PsfState.type]
 
-  def addPsfMisspeculation(bundle: DynBundle[PipelineData[Data]]): Unit
+  def addPsfState(bundle: DynBundle[PipelineData[Data]]): Unit
 
   def width(
       bundle: Bundle with DynBundleAccess[PipelineData[Data]]
@@ -232,7 +236,7 @@ trait LsuService {
 
   def widthOut(stage: Stage): SpinalEnumCraft[LsuAccessWidth.type]
 
-  def psfMisspeculationRegister: PipelineData[Data]
+  def psfStateRegister: PipelineData[Data]
 }
 
 trait ScheduleService {

--- a/src/main/scala/riscv/plugins/memory/DynamicMemoryBackbone.scala
+++ b/src/main/scala/riscv/plugins/memory/DynamicMemoryBackbone.scala
@@ -131,9 +131,13 @@ class DynamicMemoryBackbone(implicit config: Config) extends MemoryBackbone with
 
       // check whether the correct load bus is ready to receive
       when(unifiedInternalDBus.rsp.valid) {
-        unifiedInternalDBus.rsp.ready := internalReadDBuses(
-          busId2StageIndex(unifiedInternalDBus.rsp.id).stageIndex
-        ).rsp.ready
+        if (internalReadDBuses.length == 1) {
+          unifiedInternalDBus.rsp.ready := internalReadDBuses.head.rsp.ready
+        } else {
+          unifiedInternalDBus.rsp.ready := internalReadDBuses(
+            busId2StageIndex(unifiedInternalDBus.rsp.id).stageIndex.resized
+          ).rsp.ready
+        }
       }
 
       // TODO: is it possible to do the following with an arbiter instead of this manual mess?

--- a/src/main/scala/riscv/plugins/memory/Lsu.scala
+++ b/src/main/scala/riscv/plugins/memory/Lsu.scala
@@ -30,7 +30,7 @@ class Lsu(addressStages: Set[Stage], loadStages: Seq[Stage], storeStage: Stage)
     object LSU_TARGET_VALID extends PipelineData(Bool())
     object LSU_STL_SPEC extends PipelineData(Bool())
     object LSU_PSF_ADDRESS extends PipelineData(UInt(config.xlen bits))
-    object LSU_PSF_MISSPECULATION extends PipelineData(Bool())
+    object LSU_PSF_STATE extends PipelineData(PsfState())
   }
 
   class DummyFormalService extends FormalService {
@@ -492,17 +492,17 @@ class Lsu(addressStages: Set[Stage], loadStages: Seq[Stage], storeStage: Stage)
     )
   }
 
-  override def psfMisspeculation(bundle: Bundle with DynBundleAccess[PipelineData[Data]]): Bool = {
-    bundle.elementAs[Bool](Data.LSU_PSF_MISSPECULATION.asInstanceOf[PipelineData[Data]])
+  override def psfState(bundle: Bundle with DynBundleAccess[PipelineData[Data]]): SpinalEnumCraft[PsfState.type] = {
+    bundle.elementAs[SpinalEnumCraft[PsfState.type]](Data.LSU_PSF_STATE.asInstanceOf[PipelineData[Data]])
   }
 
-  override def addPsfMisspeculation(bundle: DynBundle[PipelineData[Data]]): Unit = {
+  override def addPsfState(bundle: DynBundle[PipelineData[Data]]): Unit = {
     bundle.addElement(
-      Data.LSU_PSF_MISSPECULATION.asInstanceOf[PipelineData[Data]],
-      Data.LSU_PSF_MISSPECULATION.dataType
+      Data.LSU_PSF_STATE.asInstanceOf[PipelineData[Data]],
+      Data.LSU_PSF_STATE.dataType
     )
   }
 
-  override def psfMisspeculationRegister: PipelineData[Data] =
-    Data.LSU_PSF_MISSPECULATION.asInstanceOf[PipelineData[Data]]
+  override def psfStateRegister: PipelineData[Data] =
+    Data.LSU_PSF_STATE.asInstanceOf[PipelineData[Data]]
 }

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/DynamicDataBuses.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/DynamicDataBuses.scala
@@ -25,7 +25,7 @@ case class RdbMessage(retirementRegisters: DynBundle[PipelineData[Data]], robInd
 }
 
 trait CdbListener {
-  def onCdbMessage(cdbMessage: CdbMessage)
+  def onCdbMessage(cdbMessage: Flow[CdbMessage])
 }
 
 class CommonDataBus(
@@ -43,15 +43,15 @@ class CommonDataBus(
 
   private val arbitratedInputs = StreamArbiterFactory.roundRobin.noLock.on(inputs)
 
+
   def build(): Unit = {
-    when(arbitratedInputs.valid) {
-      arbitratedInputs.ready := True
-      val listeners = reservationStations :+ rob
-      for (listener <- listeners) {
-        listener.onCdbMessage(arbitratedInputs.payload)
-      }
-    } otherwise {
-      arbitratedInputs.ready := False
+    // TODO: This fix makes the call to 'onCdbMessage' unconditional (not in a when block) so it does not cause a scope
+    // violation. It is uglier for a single message but I think it is necessary anyway when there are multiple messages.
+    val arbitratedFlow = arbitratedInputs.toFlow
+
+    val listeners = reservationStations :+ rob
+    for (listener <- listeners) {
+      listener.onCdbMessage(arbitratedFlow)
     }
   }
 }
@@ -87,11 +87,9 @@ class RobDataBus(
   private val arbitratedInputs = StreamArbiterFactory.roundRobin.noLock.on(inputs)
 
   def build(): Unit = {
-    when(arbitratedInputs.valid) {
-      arbitratedInputs.ready := True
-      rob.onRdbMessage(arbitratedInputs.payload)
-    } otherwise {
-      arbitratedInputs.ready := False
-    }
+    // TODO: This fix makes the call to 'onCdbMessage' unconditional (not in a when block) so it does not cause a scope
+    // violation. It is uglier for a single message but I think it is necessary anyway when there are multiple messages.
+    // .toFlow automatically drives arbitratedInputs.ready := True
+    rob.onRdbMessage(arbitratedInputs.toFlow)
   }
 }

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/LoadManager.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/LoadManager.scala
@@ -57,6 +57,8 @@ class LoadManager(
         stateNext := State.EXECUTING
         storedMessage := rdbMessage
 
+        discardResult := False
+
         // TODO: this is very ugly
         lsu.addressOfBundle(targetRobEntry.registerMap) := address
         lsu.addressValidOfBundle(targetRobEntry.registerMap) := True
@@ -110,7 +112,14 @@ class LoadManager(
       }
     }
 
-    lsu.psfMisspeculation(resultCdbMessage.metadata) := False
+    if (config.stlSpec && config.addressBasedPsf) {
+      // Forward the RS state (MISS) if predicting
+      lsu.psfState(cdbStream.payload.metadata).allowOverride() := lsu.psfState(storedMessage.registerMap)
+    } else {
+      // Default to NONE for normal execution
+      lsu.psfState(cdbStream.payload.metadata).allowOverride() := PsfState.NONE
+    }
+
     cdbStream.valid := False
     cdbStream.payload := resultCdbMessage
 

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
@@ -548,33 +548,39 @@ class ReorderBuffer(
       .elementAs[UInt](pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]])
     val flushPort = (new FlushPort).init(cdbMessage.robIndex, nextPc)
 
+    def processValidEntry(): Unit = {
+      entry.cdbUpdated := True
+      entry.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
+    }
+
     when(cdbMessage.valid) {
       if (config.addressBasedPsf) {
         switch(lsu.psfState(cdbMessage.metadata)) {
           is(PsfState.NONE) {
-            entry.cdbUpdated := True
-            entry.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
-          }
-          is(PsfState.WARNING) {
-            flushPort.requestPsf(pc)
-          }
-          is(PsfState.MISS) {
-            flushPort.requestPsf(pc)
-            entry.cdbUpdated := True
-            entry.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
+            processValidEntry()
           }
           is(PsfState.PREDICTION) {
             psfPredictions := psfPredictions + 1
           }
+          is(PsfState.WARNING) {
+            // Request a flush
+            flushPort.requestPsf(pc)
+          }
+          is(PsfState.MISS) {
+            // Request a flush (this may be redundant but it is technically possible that the WARNING message has not
+            // arrived yet.). The flush is still necessary because the reservation stations received the incorrect value
+            // from the prediction.
+            flushPort.requestPsf(pc)
+
+            // This message does contain the correct values, so store the values
+            processValidEntry()
+          }
         }
       } else {
-        entry.cdbUpdated := True
-        entry.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
+        processValidEntry()
       }
 
-      // TODO: Check this
       when(!entry.cdbUpdated) {
-
         if (config.addressBasedPsf) {
           lsu.psfAddress(entry.registerMap) := lsu.psfAddress(cdbMessage.metadata)
         }
@@ -695,6 +701,8 @@ class ReorderBuffer(
     val flushPort = (new FlushPort).init(rdbMessage.robIndex, nextPc)
 
     when(rdbMessage.valid) {
+
+      // Copy all pipeline data
       entry.registerMap := rdbMessage.registerMap
       entry.willCdbUpdate := rdbMessage.willCdbUpdate
 
@@ -713,7 +721,6 @@ class ReorderBuffer(
       }
 
       if (config.stlSpec) {
-
         // Exception 3: SSB
         when(
           lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.STORE
@@ -731,9 +738,7 @@ class ReorderBuffer(
             }
           }
 
-          val ssbReset = hasSpeculatingLoad(rdbMessage.robIndex, storeValue, storeAddress)
-
-          when(ssbReset) {
+          when(hasSpeculatingLoad(rdbMessage.robIndex, storeValue, storeAddress)) {
             flushPort.requestSsb(pc)
           }
         }
@@ -743,11 +748,9 @@ class ReorderBuffer(
           when(lsu.psfState(rdbMessage.registerMap) === PsfState.MISS) {
             flushPort.requestPsf(pc)
           }
-
         } else {
           // Value-based PSF Fallback
           when(lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.LOAD && entry.cdbUpdated) {
-
             val psfMismatch = rdbMessage.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) =/=
               entry.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]])
 

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
@@ -541,51 +541,55 @@ class ReorderBuffer(
     // TODO: the PSF update logic is probably way too complicated...
     val lsu = pipeline.service[LsuService]
 
-    val pc = robEntries(cdbMessage.robIndex).registerMap
+    val entry = robEntries(cdbMessage.robIndex)
+    val pc = entry.registerMap
       .elementAs[UInt](pipeline.data.PC.asInstanceOf[PipelineData[Data]])
-    val nextPc = robEntries(cdbMessage.robIndex).registerMap
+    val nextPc = entry.registerMap
       .elementAs[UInt](pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]])
     val flushPort = (new FlushPort).init(cdbMessage.robIndex, nextPc)
 
     when(cdbMessage.valid) {
       if (config.addressBasedPsf) {
-        when(lsu.psfMisspeculation(cdbMessage.metadata)) {
-          robEntries(cdbMessage.robIndex).cdbUpdated := robEntries(
-            cdbMessage.robIndex
-          ).rdbUpdated || (currentRdbUpdate.valid && currentRdbUpdate.payload === cdbMessage.robIndex)
-          currentCdbUpdate.push(cdbMessage.robIndex)
-          flushPort.requestPsf(pc)
-        } otherwise {
-          robEntries(cdbMessage.robIndex).cdbUpdated := True
-          robEntries(cdbMessage.robIndex).registerMap
-            .element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
+        switch(lsu.psfState(cdbMessage.metadata)) {
+          is(PsfState.NONE) {
+            entry.cdbUpdated := True
+            entry.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
+          }
+          is(PsfState.WARNING) {
+            flushPort.requestPsf(pc)
+          }
+          is(PsfState.MISS) {
+            flushPort.requestPsf(pc)
+            entry.cdbUpdated := True
+            entry.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
+          }
+          is(PsfState.PREDICTION) {
+            psfPredictions := psfPredictions + 1
+          }
         }
       } else {
-        robEntries(cdbMessage.robIndex).cdbUpdated := True
-        robEntries(cdbMessage.robIndex).registerMap
-          .element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
+        entry.cdbUpdated := True
+        entry.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
       }
 
-      lsu.psfAddress(robEntries(cdbMessage.robIndex).registerMap) := lsu.psfAddress(
-        cdbMessage.metadata
-      )
+      // TODO: Check this
+      when(!entry.cdbUpdated) {
 
-      pipeline.serviceOption[SpeculationService] foreach { spec =>
-        // mark PSF speculation
-        spec.isSpeculativeMD(robEntries(cdbMessage.robIndex).registerMap) := spec.isSpeculativeMD(
-          cdbMessage.metadata
-        )
-        spec.isSpeculativeCF(robEntries(cdbMessage.robIndex).registerMap) := spec.isSpeculativeCF(
-          cdbMessage.metadata
-        )
+        if (config.addressBasedPsf) {
+          lsu.psfAddress(entry.registerMap) := lsu.psfAddress(cdbMessage.metadata)
+        }
 
-        // if this instruction's CF change was correctly predicted, disregard it as the most recent speculative instruction
-        when(
-          lastSpeculativeCFInstruction.valid &&
-            lastSpeculativeCFInstruction.payload === cdbMessage.robIndex &&
-            !spec.isSpeculativeCF(cdbMessage.metadata)
-        ) {
-          lastSpeculativeCFInstruction := spec.speculationDependency(cdbMessage.metadata).resized
+        pipeline.serviceOption[SpeculationService] foreach { spec =>
+          spec.isSpeculativeMD(entry.registerMap) := spec.isSpeculativeMD(cdbMessage.metadata)
+          spec.isSpeculativeCF(entry.registerMap) := spec.isSpeculativeCF(cdbMessage.metadata)
+
+          when(
+            lastSpeculativeCFInstruction.valid &&
+              lastSpeculativeCFInstruction.payload === cdbMessage.robIndex &&
+              !spec.isSpeculativeCF(cdbMessage.metadata)
+          ) {
+            lastSpeculativeCFInstruction := spec.speculationDependency(cdbMessage.metadata).resized
+          }
         }
       }
     }
@@ -691,16 +695,17 @@ class ReorderBuffer(
     val flushPort = (new FlushPort).init(rdbMessage.robIndex, nextPc)
 
     when(rdbMessage.valid) {
-      currentRdbUpdate.push(rdbMessage.robIndex)
       entry.registerMap := rdbMessage.registerMap
       entry.willCdbUpdate := rdbMessage.willCdbUpdate
 
+      // Exception 1: Branch Misprediction
       when(nextPc =/= btb.predictedPc(rdbMessage.registerMap)) {
         flushPort.request().onSoftFlush {
           btb.preventFlush(entry.registerMap)
         }
       }
 
+      // Exception 2: CSR Serialization
       when(pipeline.service[CsrService].isCsrInstruction(rdbMessage.registerMap)) {
         flushPort.request().onSoftFlush {
           jmp.jumpOfBundle(entry.registerMap) := True
@@ -708,6 +713,8 @@ class ReorderBuffer(
       }
 
       if (config.stlSpec) {
+
+        // Exception 3: SSB
         when(
           lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.STORE
         ) {
@@ -731,53 +738,27 @@ class ReorderBuffer(
           }
         }
 
+        // Exception 4: Predictive Store Forwarding (PSF)
         if (config.addressBasedPsf) {
-          when(lsu.psfMisspeculation(rdbMessage.registerMap)) {
+          when(lsu.psfState(rdbMessage.registerMap) === PsfState.MISS) {
             flushPort.requestPsf(pc)
           }
-          when(
-            lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.LOAD
-          ) {
-            totalLoads := totalLoads + 1
-            when(
-              (currentCdbUpdate.valid && currentCdbUpdate.payload === rdbMessage.robIndex) || jmp
-                .jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap)
-            ) {
-              jmp.jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap) := True
-            } otherwise {
-              psfPredictions := psfPredictions + 1
-            }
-          }
-        }
 
-        if (!config.addressBasedPsf) {
-          // detect wrongly forwarded value-based PSF
-          when(
-            lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.LOAD && robEntries(
-              rdbMessage.robIndex
-            ).cdbUpdated
-          ) {
-            val psfMismatch: Bool = if (config.addressBasedPsf) {
-              lsu.psfAddress(robEntries(rdbMessage.robIndex).registerMap) =/= lsu.addressOfBundle(
-                rdbMessage.registerMap
-              )
-            } else {
-              rdbMessage.registerMap.element(
-                pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]
-              ) =/= robEntries(rdbMessage.robIndex).registerMap
-                .element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]])
-            }
+        } else {
+          // Value-based PSF Fallback
+          when(lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.LOAD && entry.cdbUpdated) {
+
+            val psfMismatch = rdbMessage.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) =/=
+              entry.registerMap.element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]])
 
             when(psfMismatch) {
               flushPort.requestPsf(pc)
-            } otherwise {
-              psfPredictions := psfPredictions + 1
             }
           }
         }
       }
 
-      robEntries(rdbMessage.robIndex).rdbUpdated := True
+      entry.rdbUpdated := True
     }
   }
 

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
@@ -264,6 +264,14 @@ class ReorderBuffer(
     adjusted
   }
 
+  def isOlder(a: UInt, b: UInt): Bool = {
+    relativeIndexForAbsolute(a) < relativeIndexForAbsolute(b)
+  }
+
+  def isYounger(a: UInt, b: UInt): Bool = {
+    relativeIndexForAbsolute(a) > relativeIndexForAbsolute(b)
+  }
+
   def pushEntry(): (UInt, EntryMetadata) = {
     val issueStage = pipeline.issuePipeline.stages.last
 
@@ -455,12 +463,9 @@ class ReorderBuffer(
       val entryAddress = lsuService.addressOfBundle(entry.registerMap)
       val entryWordAddress = byte2WordAddress(entryAddress)
       val addressesMatch = entryWordAddress === wordAddress
-      val isOlder = relativeIndexForAbsolute(index) < relativeIndexForAbsolute(robIndex)
 
       when(
-        isValidAbsoluteIndex(nth)
-          && isOlder
-          && entryIsStore
+        isValidAbsoluteIndex(nth) && isOlder(index, robIndex)  && entryIsStore
       ) {
         when(entryAddressValid && addressesMatch) {
           foundMatch := True

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
@@ -124,8 +124,8 @@ class ReorderBuffer(
     ssbPredictorCounter.increment()
   }
 
-  /* data structures related to predictive store forwarding (PSF)
-   *
+  /*
+   * data structures related to predictive store forwarding (PSF)
    */
 
   val psfMispredictions = RegInit(UInt(config.xlen bits).getZero)
@@ -169,39 +169,58 @@ class ReorderBuffer(
     }
   }
 
-  /*
-   * Flush mechanism arbitration classes and structures
+  /** A builder pattern helper used to attach specific callbacks or actions to a flush request
+   * depending on the type of flush (soft or hard) granted by the arbiter.
+   *
+   * @param req The parent [[FlushPort]] associated with this builder.
    */
-
-
   class FlushActionBuilder(req: FlushPort) {
+    /** Registers a block of code to execute if a soft flush is granted. */
     def onSoftFlush(block: => Unit): FlushActionBuilder = {
       when(req.grantedSoftFlush) { block }
       this
     }
 
+    /** Registers a block of code to execute if a hard flush is granted. */
     def onHardFlush(block: => Unit): FlushActionBuilder = {
       when(req.grantedHardFlush) { block }
       this
     }
 
+    /** Registers a block of code to execute if either a soft or hard flush is granted. */
     def onAnyFlush(block: => Unit): FlushActionBuilder = {
       when(req.grantedAnyFlush) { block }
       this
     }
   }
 
+  /** Represents a port through which pipeline services can request a pipeline flush.
+   * Automatically registers itself into the ROB's internal `_flushRequests` list upon creation.
+   */
   class FlushPort(implicit config: Config) extends Bundle {
-    flushRequests += this
+    // Automatically register this port into the global arbitration pool so the correct logic can be added later.
+    _flushRequests += this
 
+    /** Indicates whether this flush request is active. */
     val valid            = Bool()
+    /** The ROB index of the last correct instruction (typically the instruction requesting the flush). */
     val lastCorrectId    = UInt(indexBits)
+    /** The target program counter (PC) where execution should resume after the flush. */
     val nextPc           = UInt(config.xlen bits)
 
+    /** Set if this request wins and is serviced via a soft flush. */
     val grantedSoftFlush = Bool()
+    /** Set if this request is serviced via a hard flush. */
     val grantedHardFlush = Bool()
+    /** Helper indicating if any flush type was granted to this request. */
     def grantedAnyFlush  = grantedSoftFlush || grantedHardFlush
 
+    /** Initializes the flush port with target metadata and defaults flags to false.
+     *
+     * @param lastCorrectId The ROB index of the instruction requesting the flush.
+     * @param nextPc The target PC to jump to after flushing.
+     * @return This initialized [[FlushPort]] instance.
+     */
     def init(lastCorrectId: UInt, nextPc: UInt): FlushPort = {
       this.lastCorrectId := lastCorrectId
       this.nextPc := nextPc
@@ -211,11 +230,20 @@ class ReorderBuffer(
       this
     }
 
+    /** Activates the flush request and returns an action builder to register callbacks.
+     *
+     * @return A [[FlushActionBuilder]] for handling grant callbacks.
+     */
     def request(): FlushActionBuilder = {
       this.valid := True
       new FlushActionBuilder(this)
     }
 
+    /** Convenience method to trigger a flush due to a Predictive Store Forwarding (PSF) misprediction.
+     * Automatically trains the PSF predictor and increments the misprediction counter when granted.
+     * TODO: Should be moved to a PSF specific module later.
+     * @param pc The PC of the mispredicted instruction.
+     */
     def requestPsf(pc: UInt): Unit = {
       request().onAnyFlush {
         addPsfPredictorEntry(pc)
@@ -223,6 +251,12 @@ class ReorderBuffer(
       }
     }
 
+    /** Convenience method to trigger a flush due to a Speculative Store Bypass (SSB) misprediction.
+     * Automatically trains the SSB predictor and increments the misprediction counter when granted.
+     * TODO: Should be moved to a SSB specific module later.
+     *
+     * @param pc The PC of the mispredicted instruction.
+     */
     def requestSsb(pc: UInt): Unit = {
       request().onAnyFlush {
         addSsbPredictorEntry(pc)
@@ -231,15 +265,28 @@ class ReorderBuffer(
     }
   }
 
-  private val flushRequests = ArrayBuffer[FlushPort]()
+  /** Collection of all active flush ports instantiated during code generation. */
+  private val _flushRequests = ArrayBuffer[FlushPort]()
 
-
+  /** Evaluates all pending flush requests, arbitrates to find the oldest requesting instruction,
+   * and executes the appropriate flush mechanism (Soft Flush vs. Hard Flush).
+   *
+   * A **Soft Flush** is preferred as it immediately invalidates only younger, speculative instructions
+   * in the ROB and redirects the fetch stage without waiting for the faulting instruction to retire.
+   *
+   * Due to hardware constraints, there can only be one soft flush at a time. If it is already taken,
+   * a **Hard Flush** acts as a fallback by marking the instruction bundle to jump upon retirement
+   * completely wiping the pipeline when it reaches the end of the ROB.
+   */
   def processFlushes(): Unit = {
     var winnerFound: Bool = False
     var winningIndex: UInt = U(0, indexBits)
     var winningPc: UInt = U(0, config.xlen bits)
 
-    for (req <- flushRequests) {
+    // Iterate through all registered flush ports to find the oldest request in this cycle.
+    // In an out-of-order execution engine, the oldest instruction always takes priority to ensure
+    // program order correctness.
+    for (req <- _flushRequests) {
       val older = isOlder(req.lastCorrectId, winningIndex)
       val takeThis = req.valid && (!winnerFound || older)
 
@@ -251,26 +298,29 @@ class ReorderBuffer(
     when(winnerFound) {
       val winningEntry = robEntries(winningIndex)
 
+      // Ensure the winning entry hasn't already been invalidated by an earlier flush
+      // and that a global hard reset isn't currently taking place.
       when(!winningEntry.invalidated && !hardResetThisCycle) {
-        val winnerMask = B(flushRequests.map(req => req.valid && req.lastCorrectId === winningIndex))
+
+        // Handle edge cases where multiple ports request a flush from the EXACT same instruction index.
+        // We create a bitmask of all valid requests matching the winning index and pick the first one.
+        val winnerMask = B(_flushRequests.map(req => req.valid && req.lastCorrectId === winningIndex))
         val singleWinnerOH = OHMasking.firstV2(winnerMask)
 
-        // 1. Isolate the retirement check adapted for single-retire ROB
+        // Check if the current soft reset is still valid or if it can be replaced.
         val currentTriggerRetiring = softResetTrigger.valid &&
           softResetTrigger.payload === oldestIndex.value &&
           willRetire
-
-        // 2. Define `currentTriggerValid` as an ACTIVE trigger, not just a retiring one
         val currentTriggerValid = softResetTrigger.valid && !currentTriggerRetiring
-
-        // 3. Routing booleans utilizing the corrected active state
         val isRedundant = currentTriggerValid && winningIndex === softResetTrigger.payload
+
+        // We can perform a soft flush if there is no active trigger, or if the new flush is older than the existing trigger.
         val canSoftFlush = !currentTriggerValid || isOlder(winningIndex, softResetTrigger.payload)
 
         when(isRedundant) {
-          // Do nothing
+          // Do nothing; the pipeline is already scheduled to flush from this instruction point.
         } elsewhen(canSoftFlush) {
-          // --- SOFT FLUSH ---
+          // --- SOFT FLUSH EXECUTION ---
           fenceDetected := False
           softResetThisCycle := True
           softResetTrigger.push(winningIndex)
@@ -280,12 +330,14 @@ class ReorderBuffer(
           pipeline.issuePipeline.service[JumpService].jump(winningPc)
           lastSpeculativeCFInstruction.setIdle()
 
-          for ((req, i) <- flushRequests.zipWithIndex) {
+          // Grant the soft flush signal to the winning port to trigger its `onSoftFlush` / `onAnyFlush` callbacks.
+          for ((req, i) <- _flushRequests.zipWithIndex) {
             when(singleWinnerOH(i)) {
               req.grantedSoftFlush := True
             }
           }
 
+          // Invalidate all ROB entries younger than the winning instruction.
           for (relative <- 0 until capacity) {
             val absolute = absoluteIndexForRelative(relative).resized
             val entry = robEntries(absolute)
@@ -293,6 +345,7 @@ class ReorderBuffer(
               when(relative > relativeIndexForAbsolute(winningIndex)) {
                 entry.invalidated := True
               } otherwise {
+                // For surviving older entries, update the latest speculative control-flow tracking.
                 pipeline.serviceOption[SpeculationService] foreach { spec =>
                   when(spec.isSpeculativeCF(entry.registerMap)) {
                     lastSpeculativeCFInstruction.push(absolute)
@@ -304,9 +357,12 @@ class ReorderBuffer(
           softFlushCounter := softFlushCounter + 1
         } otherwise {
           // --- HARD FLUSH FALLBACK ---
+          // If a soft flush cannot be applied, defer the flush until the winning instruction retires.
+          // This is done by asserting the jump flag on the instruction's register bundle.
           pipeline.service[JumpService].jumpOfBundle(winningEntry.registerMap) := True
 
-          for ((req, i) <- flushRequests.zipWithIndex) {
+          // Grant the hard flush signal to the winning port to trigger its `onHardFlush` / `onAnyFlush` callbacks.
+          for ((req, i) <- _flushRequests.zipWithIndex) {
             when(singleWinnerOH(i)) {
               req.grantedHardFlush := True
             }

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
@@ -537,54 +537,56 @@ class ReorderBuffer(
     meta
   }
 
-  override def onCdbMessage(cdbMessage: CdbMessage): Unit = {
+  override def onCdbMessage(cdbMessage: Flow[CdbMessage]): Unit = {
     // TODO: the PSF update logic is probably way too complicated...
     val lsu = pipeline.service[LsuService]
-    if (config.addressBasedPsf) {
-      when(lsu.psfMisspeculation(cdbMessage.metadata)) {
-        robEntries(cdbMessage.robIndex).cdbUpdated := robEntries(
-          cdbMessage.robIndex
-        ).rdbUpdated || (currentRdbUpdate.valid && currentRdbUpdate.payload === cdbMessage.robIndex)
-        currentCdbUpdate.push(cdbMessage.robIndex)
 
-        val pc = robEntries(cdbMessage.robIndex).registerMap
-          .elementAs[UInt](pipeline.data.PC.asInstanceOf[PipelineData[Data]])
-        val nextPc = robEntries(cdbMessage.robIndex).registerMap
-          .elementAs[UInt](pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]])
-        val flushPort = (new FlushPort).init(cdbMessage.robIndex, nextPc)
+    val pc = robEntries(cdbMessage.robIndex).registerMap
+      .elementAs[UInt](pipeline.data.PC.asInstanceOf[PipelineData[Data]])
+    val nextPc = robEntries(cdbMessage.robIndex).registerMap
+      .elementAs[UInt](pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]])
+    val flushPort = (new FlushPort).init(cdbMessage.robIndex, nextPc)
 
-        flushPort.requestPsf(pc)
-      } otherwise {
+    when(cdbMessage.valid) {
+      if (config.addressBasedPsf) {
+        when(lsu.psfMisspeculation(cdbMessage.metadata)) {
+          robEntries(cdbMessage.robIndex).cdbUpdated := robEntries(
+            cdbMessage.robIndex
+          ).rdbUpdated || (currentRdbUpdate.valid && currentRdbUpdate.payload === cdbMessage.robIndex)
+          currentCdbUpdate.push(cdbMessage.robIndex)
+          flushPort.requestPsf(pc)
+        } otherwise {
+          robEntries(cdbMessage.robIndex).cdbUpdated := True
+          robEntries(cdbMessage.robIndex).registerMap
+            .element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
+        }
+      } else {
         robEntries(cdbMessage.robIndex).cdbUpdated := True
         robEntries(cdbMessage.robIndex).registerMap
           .element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
       }
-    } else {
-      robEntries(cdbMessage.robIndex).cdbUpdated := True
-      robEntries(cdbMessage.robIndex).registerMap
-        .element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]) := cdbMessage.writeValue
-    }
 
-    lsu.psfAddress(robEntries(cdbMessage.robIndex).registerMap) := lsu.psfAddress(
-      cdbMessage.metadata
-    )
-
-    pipeline.serviceOption[SpeculationService] foreach { spec =>
-      // mark PSF speculation
-      spec.isSpeculativeMD(robEntries(cdbMessage.robIndex).registerMap) := spec.isSpeculativeMD(
-        cdbMessage.metadata
-      )
-      spec.isSpeculativeCF(robEntries(cdbMessage.robIndex).registerMap) := spec.isSpeculativeCF(
+      lsu.psfAddress(robEntries(cdbMessage.robIndex).registerMap) := lsu.psfAddress(
         cdbMessage.metadata
       )
 
-      // if this instruction's CF change was correctly predicted, disregard it as the most recent speculative instruction
-      when(
-        lastSpeculativeCFInstruction.valid &&
-          lastSpeculativeCFInstruction.payload === cdbMessage.robIndex &&
-          !spec.isSpeculativeCF(cdbMessage.metadata)
-      ) {
-        lastSpeculativeCFInstruction := spec.speculationDependency(cdbMessage.metadata).resized
+      pipeline.serviceOption[SpeculationService] foreach { spec =>
+        // mark PSF speculation
+        spec.isSpeculativeMD(robEntries(cdbMessage.robIndex).registerMap) := spec.isSpeculativeMD(
+          cdbMessage.metadata
+        )
+        spec.isSpeculativeCF(robEntries(cdbMessage.robIndex).registerMap) := spec.isSpeculativeCF(
+          cdbMessage.metadata
+        )
+
+        // if this instruction's CF change was correctly predicted, disregard it as the most recent speculative instruction
+        when(
+          lastSpeculativeCFInstruction.valid &&
+            lastSpeculativeCFInstruction.payload === cdbMessage.robIndex &&
+            !spec.isSpeculativeCF(cdbMessage.metadata)
+        ) {
+          lastSpeculativeCFInstruction := spec.speculationDependency(cdbMessage.metadata).resized
+        }
       }
     }
   }
@@ -677,7 +679,7 @@ class ReorderBuffer(
     found
   }
 
-  def onRdbMessage(rdbMessage: RdbMessage): Unit = {
+  def onRdbMessage(rdbMessage: Flow[RdbMessage]): Unit = {
     val btb = pipeline.service[BranchTargetPredictorService]
     val jmp = pipeline.service[JumpService]
     val lsu = pipeline.service[LsuService]
@@ -688,93 +690,95 @@ class ReorderBuffer(
 
     val flushPort = (new FlushPort).init(rdbMessage.robIndex, nextPc)
 
-    currentRdbUpdate.push(rdbMessage.robIndex)
-    entry.registerMap := rdbMessage.registerMap
-    entry.willCdbUpdate := rdbMessage.willCdbUpdate
+    when(rdbMessage.valid) {
+      currentRdbUpdate.push(rdbMessage.robIndex)
+      entry.registerMap := rdbMessage.registerMap
+      entry.willCdbUpdate := rdbMessage.willCdbUpdate
 
-    when(nextPc =/= btb.predictedPc(rdbMessage.registerMap)) {
-      flushPort.request().onSoftFlush {
-        btb.preventFlush(entry.registerMap)
-      }
-    }
-
-    when(pipeline.service[CsrService].isCsrInstruction(rdbMessage.registerMap)) {
-      flushPort.request().onSoftFlush {
-        jmp.jumpOfBundle(entry.registerMap) := True
-      }
-    }
-
-    if (config.stlSpec) {
-      when(
-        lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.STORE
-      ) {
-        val storeValue = rdbMessage.registerMap.elementAs[UInt](
-          pipeline.data.RS2_DATA.asInstanceOf[PipelineData[Data]]
-        )
-        val storeAddress = lsu.addressOfBundle(rdbMessage.registerMap)
-        currentlyInsertingStore.push(storeAddress)
-        when(lsu.width(rdbMessage.registerMap) === LsuAccessWidth.W) {
-          // for now, we only predict word memory operation
-          previousStoreBuffer := storeValue
-          if (config.addressBasedPsf) {
-            previousStoreAddress := storeAddress
-          }
-        }
-
-        val ssbReset = hasSpeculatingLoad(rdbMessage.robIndex, storeValue, storeAddress)
-
-        when(ssbReset) {
-          flushPort.requestSsb(pc)
+      when(nextPc =/= btb.predictedPc(rdbMessage.registerMap)) {
+        flushPort.request().onSoftFlush {
+          btb.preventFlush(entry.registerMap)
         }
       }
 
-      if (config.addressBasedPsf) {
-        when(lsu.psfMisspeculation(rdbMessage.registerMap)) {
-          flushPort.requestPsf(pc)
+      when(pipeline.service[CsrService].isCsrInstruction(rdbMessage.registerMap)) {
+        flushPort.request().onSoftFlush {
+          jmp.jumpOfBundle(entry.registerMap) := True
         }
+      }
+
+      if (config.stlSpec) {
         when(
-          lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.LOAD
+          lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.STORE
         ) {
-          totalLoads := totalLoads + 1
-          when(
-            (currentCdbUpdate.valid && currentCdbUpdate.payload === rdbMessage.robIndex) || jmp
-              .jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap)
-          ) {
-            jmp.jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap) := True
-          } otherwise {
-            psfPredictions := psfPredictions + 1
+          val storeValue = rdbMessage.registerMap.elementAs[UInt](
+            pipeline.data.RS2_DATA.asInstanceOf[PipelineData[Data]]
+          )
+          val storeAddress = lsu.addressOfBundle(rdbMessage.registerMap)
+          currentlyInsertingStore.push(storeAddress)
+          when(lsu.width(rdbMessage.registerMap) === LsuAccessWidth.W) {
+            // for now, we only predict word memory operation
+            previousStoreBuffer := storeValue
+            if (config.addressBasedPsf) {
+              previousStoreAddress := storeAddress
+            }
+          }
+
+          val ssbReset = hasSpeculatingLoad(rdbMessage.robIndex, storeValue, storeAddress)
+
+          when(ssbReset) {
+            flushPort.requestSsb(pc)
           }
         }
-      }
 
-      if (!config.addressBasedPsf) {
-        // detect wrongly forwarded value-based PSF
-        when(
-          lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.LOAD && robEntries(
-            rdbMessage.robIndex
-          ).cdbUpdated
-        ) {
-          val psfMismatch: Bool = if (config.addressBasedPsf) {
-            lsu.psfAddress(robEntries(rdbMessage.robIndex).registerMap) =/= lsu.addressOfBundle(
-              rdbMessage.registerMap
-            )
-          } else {
-            rdbMessage.registerMap.element(
-              pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]
-            ) =/= robEntries(rdbMessage.robIndex).registerMap
-              .element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]])
-          }
-
-          when(psfMismatch) {
+        if (config.addressBasedPsf) {
+          when(lsu.psfMisspeculation(rdbMessage.registerMap)) {
             flushPort.requestPsf(pc)
-          } otherwise {
-            psfPredictions := psfPredictions + 1
+          }
+          when(
+            lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.LOAD
+          ) {
+            totalLoads := totalLoads + 1
+            when(
+              (currentCdbUpdate.valid && currentCdbUpdate.payload === rdbMessage.robIndex) || jmp
+                .jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap)
+            ) {
+              jmp.jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap) := True
+            } otherwise {
+              psfPredictions := psfPredictions + 1
+            }
+          }
+        }
+
+        if (!config.addressBasedPsf) {
+          // detect wrongly forwarded value-based PSF
+          when(
+            lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.LOAD && robEntries(
+              rdbMessage.robIndex
+            ).cdbUpdated
+          ) {
+            val psfMismatch: Bool = if (config.addressBasedPsf) {
+              lsu.psfAddress(robEntries(rdbMessage.robIndex).registerMap) =/= lsu.addressOfBundle(
+                rdbMessage.registerMap
+              )
+            } else {
+              rdbMessage.registerMap.element(
+                pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]]
+              ) =/= robEntries(rdbMessage.robIndex).registerMap
+                .element(pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]])
+            }
+
+            when(psfMismatch) {
+              flushPort.requestPsf(pc)
+            } otherwise {
+              psfPredictions := psfPredictions + 1
+            }
           }
         }
       }
-    }
 
-    robEntries(rdbMessage.robIndex).rdbUpdated := True
+      robEntries(rdbMessage.robIndex).rdbUpdated := True
+    }
   }
 
   def build(): Unit = {

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
@@ -312,7 +312,7 @@ class ReorderBuffer(
           softResetTrigger.payload === oldestIndex.value &&
           willRetire
         val currentTriggerValid = softResetTrigger.valid && !currentTriggerRetiring
-        val isRedundant = currentTriggerValid && winningIndex === softResetTrigger.payload
+        val isRedundant = currentTriggerValid && winningIndex === softResetTrigger.payload || pipeline.service[JumpService].jumpOfBundle(winningEntry.registerMap)
 
         // We can perform a soft flush if there is no active trigger, or if the new flush is older than the existing trigger.
         val canSoftFlush = !currentTriggerValid || isOlder(winningIndex, softResetTrigger.payload)

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
@@ -782,8 +782,6 @@ class ReorderBuffer(
   }
 
   def build(): Unit = {
-    processFlushes()
-
     isFullNext := isFull
     fenceDetectedNext := fenceDetected
     val oldestEntry = robEntries(oldestIndex.value)

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/ReorderBuffer.scala
@@ -2,7 +2,10 @@ package riscv.plugins.scheduling.dynamic
 
 import riscv._
 import spinal.core._
-import spinal.lib.{Counter, Flow}
+import spinal.lib._
+
+import scala.collection.mutable.ArrayBuffer
+import scala.language.postfixOps
 
 case class RobEntry(retirementRegisters: DynBundle[PipelineData[Data]])(implicit config: Config)
     extends Bundle {
@@ -82,8 +85,6 @@ class ReorderBuffer(
   currentSoftResetTrigger.setIdle()
   val currentCdbUpdate = Flow(UInt(indexBits))
   currentCdbUpdate.setIdle()
-  val currentCdbSoftReset = Bool()
-  currentCdbSoftReset := False
   val currentRdbUpdate = Flow(UInt(indexBits))
   currentRdbUpdate.setIdle()
 
@@ -129,6 +130,7 @@ class ReorderBuffer(
 
   val psfMispredictions = RegInit(UInt(config.xlen bits).getZero)
   val psfPredictions = RegInit(UInt(config.xlen bits).getZero)
+  val totalLoads = RegInit(UInt(config.xlen bits).getZero)
 
   val previousStoreBuffer = RegInit(UInt(config.xlen bits).getZero)
   val previousStoreAddress =
@@ -167,47 +169,151 @@ class ReorderBuffer(
     }
   }
 
-  private def softFlush(lastCorrectId: UInt, nextPc: UInt): Bool = {
-    val ret = False
-    // prevent flushes caused by transient instructions
-    when(!robEntries(lastCorrectId).invalidated && !hardResetThisCycle && !softResetTrigger.valid) {
-      // this is fine, because fences are always the last instruction in the ROB (cannot insert anything else while it's present)
-      fenceDetected := False
+  /*
+   * Flush mechanism arbitration classes and structures
+   */
 
-      softResetThisCycle := True
-      softResetTrigger.push(lastCorrectId)
-      currentSoftResetTrigger.push(lastCorrectId)
-      newestAtSoftReset := newestIndex
 
-      // set fetch PC to correct next PC (even if it was predicted as something else) and invalidate issuepipeline stages
-      pipeline.issuePipeline.service[JumpService].jump(nextPc)
+  class FlushActionBuilder(req: FlushPort) {
+    def onSoftFlush(block: => Unit): FlushActionBuilder = {
+      when(req.grantedSoftFlush) { block }
+      this
+    }
 
-      // reset last speculative instruction
-      lastSpeculativeCFInstruction.setIdle()
+    def onHardFlush(block: => Unit): FlushActionBuilder = {
+      when(req.grantedHardFlush) { block }
+      this
+    }
 
-      // ensure entries between oldest and newest are invalidated -> new entry should only be pushed
-      //     if rob/cdb updates are already there for invalid or stages got invalidated
-      for (relative <- 0 until capacity) {
-        val absolute = absoluteIndexForRelative(relative).resized
-        val entry = robEntries(absolute)
-        when(isValidAbsoluteIndex(absolute)) {
-          when(relative > relativeIndexForAbsolute(lastCorrectId)) {
-            entry.invalidated := True
-          } otherwise {
-            // if there are still valid control-flow speculation instructions, set the youngest one as the last
-            pipeline.serviceOption[SpeculationService] foreach { spec =>
-              when(spec.isSpeculativeCF(entry.registerMap)) {
-                lastSpeculativeCFInstruction.push(absolute)
+    def onAnyFlush(block: => Unit): FlushActionBuilder = {
+      when(req.grantedAnyFlush) { block }
+      this
+    }
+  }
+
+  class FlushPort(implicit config: Config) extends Bundle {
+    flushRequests += this
+
+    val valid            = Bool()
+    val lastCorrectId    = UInt(indexBits)
+    val nextPc           = UInt(config.xlen bits)
+
+    val grantedSoftFlush = Bool()
+    val grantedHardFlush = Bool()
+    def grantedAnyFlush  = grantedSoftFlush || grantedHardFlush
+
+    def init(lastCorrectId: UInt, nextPc: UInt): FlushPort = {
+      this.lastCorrectId := lastCorrectId
+      this.nextPc := nextPc
+      this.valid := False
+      this.grantedSoftFlush := False
+      this.grantedHardFlush := False
+      this
+    }
+
+    def request(): FlushActionBuilder = {
+      this.valid := True
+      new FlushActionBuilder(this)
+    }
+
+    def requestPsf(pc: UInt): Unit = {
+      request().onAnyFlush {
+        addPsfPredictorEntry(pc)
+        psfMispredictions := psfMispredictions + 1
+      }
+    }
+
+    def requestSsb(pc: UInt): Unit = {
+      request().onAnyFlush {
+        addSsbPredictorEntry(pc)
+        ssbMispredictions := ssbMispredictions + 1
+      }
+    }
+  }
+
+  private val flushRequests = ArrayBuffer[FlushPort]()
+
+
+  def processFlushes(): Unit = {
+    var winnerFound: Bool = False
+    var winningIndex: UInt = U(0, indexBits)
+    var winningPc: UInt = U(0, config.xlen bits)
+
+    for (req <- flushRequests) {
+      val older = isOlder(req.lastCorrectId, winningIndex)
+      val takeThis = req.valid && (!winnerFound || older)
+
+      winnerFound = winnerFound || req.valid
+      winningIndex = Mux(takeThis, req.lastCorrectId, winningIndex)
+      winningPc = Mux(takeThis, req.nextPc, winningPc)
+    }
+
+    when(winnerFound) {
+      val winningEntry = robEntries(winningIndex)
+
+      when(!winningEntry.invalidated && !hardResetThisCycle) {
+        val winnerMask = B(flushRequests.map(req => req.valid && req.lastCorrectId === winningIndex))
+        val singleWinnerOH = OHMasking.firstV2(winnerMask)
+
+        // 1. Isolate the retirement check adapted for single-retire ROB
+        val currentTriggerRetiring = softResetTrigger.valid &&
+          softResetTrigger.payload === oldestIndex.value &&
+          willRetire
+
+        // 2. Define `currentTriggerValid` as an ACTIVE trigger, not just a retiring one
+        val currentTriggerValid = softResetTrigger.valid && !currentTriggerRetiring
+
+        // 3. Routing booleans utilizing the corrected active state
+        val isRedundant = currentTriggerValid && winningIndex === softResetTrigger.payload
+        val canSoftFlush = !currentTriggerValid || isOlder(winningIndex, softResetTrigger.payload)
+
+        when(isRedundant) {
+          // Do nothing
+        } elsewhen(canSoftFlush) {
+          // --- SOFT FLUSH ---
+          fenceDetected := False
+          softResetThisCycle := True
+          softResetTrigger.push(winningIndex)
+          currentSoftResetTrigger.push(winningIndex)
+          newestAtSoftReset := newestIndex.value
+
+          pipeline.issuePipeline.service[JumpService].jump(winningPc)
+          lastSpeculativeCFInstruction.setIdle()
+
+          for ((req, i) <- flushRequests.zipWithIndex) {
+            when(singleWinnerOH(i)) {
+              req.grantedSoftFlush := True
+            }
+          }
+
+          for (relative <- 0 until capacity) {
+            val absolute = absoluteIndexForRelative(relative).resized
+            val entry = robEntries(absolute)
+            when(isValidAbsoluteIndex(absolute)) {
+              when(relative > relativeIndexForAbsolute(winningIndex)) {
+                entry.invalidated := True
+              } otherwise {
+                pipeline.serviceOption[SpeculationService] foreach { spec =>
+                  when(spec.isSpeculativeCF(entry.registerMap)) {
+                    lastSpeculativeCFInstruction.push(absolute)
+                  }
+                }
               }
+            }
+          }
+          softFlushCounter := softFlushCounter + 1
+        } otherwise {
+          // --- HARD FLUSH FALLBACK ---
+          pipeline.service[JumpService].jumpOfBundle(winningEntry.registerMap) := True
+
+          for ((req, i) <- flushRequests.zipWithIndex) {
+            when(singleWinnerOH(i)) {
+              req.grantedHardFlush := True
             }
           }
         }
       }
-      softFlushCounter := softFlushCounter + 1
-
-      ret := True
     }
-    ret
   }
 
   private def byte2WordAddress(address: UInt) = {
@@ -384,24 +490,14 @@ class ReorderBuffer(
           cdbMessage.robIndex
         ).rdbUpdated || (currentRdbUpdate.valid && currentRdbUpdate.payload === cdbMessage.robIndex)
         currentCdbUpdate.push(cdbMessage.robIndex)
-        // do not update stored value when it's a misprediction update
-        psfMispredictions := psfMispredictions + 1
-        addPsfPredictorEntry(
-          robEntries(cdbMessage.robIndex).registerMap
-            .elementAs[UInt](pipeline.data.PC.asInstanceOf[PipelineData[Data]])
-        )
-        val flushed = softFlush(
-          cdbMessage.robIndex,
-          robEntries(cdbMessage.robIndex).registerMap.elementAs[UInt](
-            pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]]
-          )
-        )
-        currentCdbSoftReset := flushed
-        when(!flushed) {
-          pipeline
-            .service[JumpService]
-            .jumpOfBundle(robEntries(cdbMessage.robIndex).registerMap) := True
-        }
+
+        val pc = robEntries(cdbMessage.robIndex).registerMap
+          .elementAs[UInt](pipeline.data.PC.asInstanceOf[PipelineData[Data]])
+        val nextPc = robEntries(cdbMessage.robIndex).registerMap
+          .elementAs[UInt](pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]])
+        val flushPort = (new FlushPort).init(cdbMessage.robIndex, nextPc)
+
+        flushPort.requestPsf(pc)
       } otherwise {
         robEntries(cdbMessage.robIndex).cdbUpdated := True
         robEntries(cdbMessage.robIndex).registerMap
@@ -504,18 +600,18 @@ class ReorderBuffer(
       val loadValue: UInt =
         entry.registerMap.elementAs[UInt](pipeline.data.RD_DATA.asInstanceOf[PipelineData[Data]])
       val valueValid = entry.cdbUpdated
-      val isYounger = relativeIndexForAbsolute(index) > relativeIndexForAbsolute(storeIndex)
+      val younger = isYounger(index, storeIndex)
 
       val speculative = pipeline.service[LsuService].stlSpeculation(entry.registerMap)
 
       val entriesMatch: Bool = if (config.addressBasedSsb) {
         isValidAbsoluteIndex(
           nth
-        ) && entryIsLoad && isYounger && (entryAddressValid && addressesMatch && speculative)
+        ) && entryIsLoad && younger && (entryAddressValid && addressesMatch && speculative)
       } else {
         isValidAbsoluteIndex(
           nth
-        ) && entryIsLoad && isYounger && (entryAddressValid && addressesMatch && speculative) && (!valueValid || storeValue =/= loadValue)
+        ) && entryIsLoad && younger && (entryAddressValid && addressesMatch && speculative) && (!valueValid || storeValue =/= loadValue)
       }
 
       when(entriesMatch) {
@@ -530,44 +626,25 @@ class ReorderBuffer(
     val jmp = pipeline.service[JumpService]
     val lsu = pipeline.service[LsuService]
 
+    val entry = robEntries(rdbMessage.robIndex)
+    val pc = entry.registerMap.elementAs[UInt](pipeline.data.PC.asInstanceOf[PipelineData[Data]])
+    val nextPc = rdbMessage.registerMap.elementAs[UInt](pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]])
+
+    val flushPort = (new FlushPort).init(rdbMessage.robIndex, nextPc)
+
     currentRdbUpdate.push(rdbMessage.robIndex)
-    robEntries(rdbMessage.robIndex).registerMap := rdbMessage.registerMap
-    robEntries(rdbMessage.robIndex).willCdbUpdate := rdbMessage.willCdbUpdate
+    entry.registerMap := rdbMessage.registerMap
+    entry.willCdbUpdate := rdbMessage.willCdbUpdate
 
-    when(
-      rdbMessage.registerMap.elementAs[UInt](
-        pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]]
-      ) =/= btb.predictedPc(rdbMessage.registerMap)
-    ) {
-      val flushed = False
-      when(!currentCdbSoftReset) {
-        flushed := softFlush(
-          rdbMessage.robIndex,
-          rdbMessage.registerMap.elementAs[UInt](
-            pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]]
-          )
-        )
-      }
-
-      when(flushed) {
-        btb.preventFlush(robEntries(rdbMessage.robIndex).registerMap)
+    when(nextPc =/= btb.predictedPc(rdbMessage.registerMap)) {
+      flushPort.request().onSoftFlush {
+        btb.preventFlush(entry.registerMap)
       }
     }
 
     when(pipeline.service[CsrService].isCsrInstruction(rdbMessage.registerMap)) {
-      jmp.jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap) := True
-      val flushed = False
-      when(!currentCdbSoftReset) {
-        flushed := softFlush(
-          rdbMessage.robIndex,
-          rdbMessage.registerMap.elementAs[UInt](
-            pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]]
-          )
-        )
-      }
-
-      when(!flushed) {
-        // CSR reads are not correctly handled, so for now we always flush
+      flushPort.request().onSoftFlush {
+        jmp.jumpOfBundle(entry.registerMap) := True
       }
     }
 
@@ -591,47 +668,18 @@ class ReorderBuffer(
         val ssbReset = hasSpeculatingLoad(rdbMessage.robIndex, storeValue, storeAddress)
 
         when(ssbReset) {
-          addSsbPredictorEntry(
-            rdbMessage.registerMap.elementAs[UInt](
-              pipeline.data.PC.asInstanceOf[PipelineData[Data]]
-            )
-          )
-          ssbMispredictions := ssbMispredictions + 1
-          val flushed = False
-          when(!currentCdbSoftReset) {
-            flushed := softFlush(
-              rdbMessage.robIndex,
-              rdbMessage.registerMap.elementAs[UInt](
-                pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]]
-              )
-            )
-          }
-          when(!flushed) {
-            jmp.jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap) := True
-          }
+          flushPort.requestSsb(pc)
         }
       }
 
       if (config.addressBasedPsf) {
         when(lsu.psfMisspeculation(rdbMessage.registerMap)) {
-          psfMispredictions := psfMispredictions + 1
-          addPsfPredictorEntry(
-            robEntries(rdbMessage.robIndex).registerMap
-              .elementAs[UInt](pipeline.data.PC.asInstanceOf[PipelineData[Data]])
-          )
-          val flushed = softFlush(
-            rdbMessage.robIndex,
-            rdbMessage.registerMap.elementAs[UInt](
-              pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]]
-            )
-          )
-          when(!flushed) {
-            jmp.jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap) := True
-          }
+          flushPort.requestPsf(pc)
         }
         when(
           lsu.operationOfBundle(rdbMessage.registerMap) === LsuOperationType.LOAD
         ) {
+          totalLoads := totalLoads + 1
           when(
             (currentCdbUpdate.valid && currentCdbUpdate.payload === rdbMessage.robIndex) || jmp
               .jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap)
@@ -662,23 +710,7 @@ class ReorderBuffer(
           }
 
           when(psfMismatch) {
-            psfMispredictions := psfMispredictions + 1
-            addPsfPredictorEntry(
-              robEntries(rdbMessage.robIndex).registerMap
-                .elementAs[UInt](pipeline.data.PC.asInstanceOf[PipelineData[Data]])
-            )
-            val flushed = False
-            when(!currentCdbSoftReset) {
-              flushed := softFlush(
-                rdbMessage.robIndex,
-                rdbMessage.registerMap.elementAs[UInt](
-                  pipeline.data.NEXT_PC.asInstanceOf[PipelineData[Data]]
-                )
-              )
-            }
-            when(!flushed) {
-              jmp.jumpOfBundle(robEntries(rdbMessage.robIndex).registerMap) := True
-            }
+            flushPort.requestPsf(pc)
           } otherwise {
             psfPredictions := psfPredictions + 1
           }
@@ -690,6 +722,8 @@ class ReorderBuffer(
   }
 
   def build(): Unit = {
+    processFlushes()
+
     isFullNext := isFull
     fenceDetectedNext := fenceDetected
     val oldestEntry = robEntries(oldestIndex.value)

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/ReservationStation.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/ReservationStation.scala
@@ -19,7 +19,7 @@ case class RegisterSource(indexBits: BitCount) extends Bundle {
 }
 
 case class InstructionDependencies(indexBits: BitCount, speculationTracking: Boolean)
-    extends Bundle {
+  extends Bundle {
   val rs1: RegisterSource = RegisterSource(indexBits)
   val rs2: RegisterSource = RegisterSource(indexBits)
 
@@ -47,13 +47,13 @@ case class InstructionDependencies(indexBits: BitCount, speculationTracking: Boo
 }
 
 class ReservationStation(
-    exeStage: Stage,
-    rob: ReorderBuffer,
-    pipeline: DynamicPipeline,
-    retirementRegisters: DynBundle[PipelineData[Data]],
-    metaRegisters: DynBundle[PipelineData[Data]]
-)(implicit config: Config)
-    extends Area
+                          exeStage: Stage,
+                          rob: ReorderBuffer,
+                          pipeline: DynamicPipeline,
+                          retirementRegisters: DynBundle[PipelineData[Data]],
+                          metaRegisters: DynBundle[PipelineData[Data]]
+                        )(implicit config: Config)
+  extends Area
     with CdbListener
     with Resettable {
   setPartialName(s"RS_${exeStage.stageName}")
@@ -104,16 +104,11 @@ class ReservationStation(
     noPsfPrediction := False
   }
 
-  override def onCdbMessage(cdbMessage: CdbMessage): Unit = {
-    val currentRs1Prior, currentRs2Prior = Flow(UInt(rob.indexBits))
+  override def onCdbMessage(cdbMessage: Flow[CdbMessage]): Unit = {
+    val currentRs1Prior = Flow(UInt(rob.indexBits))
+    val currentRs2Prior = Flow(UInt(rob.indexBits))
     val currentLoadSpeculation = if (speculationTracking) Bool() else null
     val branchWaiting: Flow[UInt] = if (speculationTracking) Flow(UInt(rob.indexBits)) else null
-
-    when(state === State.EXECUTING || state === State.BROADCASTING_RESULT) {
-      when(cdbMessage.robIndex === robEntryIndex) {
-        cdbWaiting := False
-      }
-    }
 
     when(state === State.WAITING_FOR_ARGS) {
       currentRs1Prior := meta.rs1.priorInstruction
@@ -131,8 +126,30 @@ class ReservationStation(
       }
     }
 
-    pipeline.serviceOption[SpeculationService] foreach { spec =>
-      {
+    val r1w = Bool()
+    r1w := False
+    val r2w = Bool()
+    r2w := False
+    val lsw = if (speculationTracking) Bool() else null
+    if (speculationTracking) lsw := False
+
+    when(state === State.WAITING_FOR_ARGS || stateNext === State.WAITING_FOR_ARGS) {
+      r1w := currentRs1Prior.valid
+      r2w := currentRs2Prior.valid
+      if (speculationTracking) {
+        lsw := currentLoadSpeculation
+      }
+    }
+
+    when(cdbMessage.valid) {
+
+      when(state === State.EXECUTING || state === State.BROADCASTING_RESULT) {
+        when(cdbMessage.robIndex === robEntryIndex) {
+          cdbWaiting := False
+        }
+      }
+
+      pipeline.serviceOption[SpeculationService] foreach { spec => {
         // keep track of incoming branch updates, even if already executing
         when(branchWaiting.valid && cdbMessage.robIndex === branchWaiting.payload) {
           val pending = spec.speculationDependency(cdbMessage.metadata)
@@ -143,42 +160,36 @@ class ReservationStation(
           }
         }
       }
+      }
+
+      when(state === State.WAITING_FOR_ARGS || stateNext === State.WAITING_FOR_ARGS) {
+        when(currentRs1Prior.valid && cdbMessage.robIndex === currentRs1Prior.payload) {
+          meta.rs1.priorInstruction.valid := False
+          r1w := False
+          pipeline.serviceOption[SpeculationService] foreach { spec =>
+            when(spec.isSpeculativeMD(cdbMessage.metadata)) {
+              meta.loadSpeculation := True
+              lsw := True
+            }
+          }
+          regs.setReg(pipeline.data.RS1_DATA, cdbMessage.writeValue)
+        }
+
+        when(currentRs2Prior.valid && cdbMessage.robIndex === currentRs2Prior.payload) {
+          meta.rs2.priorInstruction.valid := False
+          r2w := False
+          pipeline.serviceOption[SpeculationService] foreach { spec =>
+            when(spec.isSpeculativeMD(cdbMessage.metadata)) {
+              meta.loadSpeculation := True
+              lsw := True
+            }
+          }
+          regs.setReg(pipeline.data.RS2_DATA, cdbMessage.writeValue)
+        }
+      }
     }
 
     when(state === State.WAITING_FOR_ARGS || stateNext === State.WAITING_FOR_ARGS) {
-      val r1w = Bool()
-      r1w := currentRs1Prior.valid
-      val r2w = Bool()
-      r2w := currentRs2Prior.valid
-      val lsw = if (speculationTracking) Bool() else null
-      if (speculationTracking) {
-        lsw := currentLoadSpeculation
-      }
-
-      when(currentRs1Prior.valid && cdbMessage.robIndex === currentRs1Prior.payload) {
-        meta.rs1.priorInstruction.valid := False
-        r1w := False
-        pipeline.serviceOption[SpeculationService] foreach { spec =>
-          when(spec.isSpeculativeMD(cdbMessage.metadata)) {
-            meta.loadSpeculation := True
-            lsw := True
-          }
-        }
-        regs.setReg(pipeline.data.RS1_DATA, cdbMessage.writeValue)
-      }
-
-      when(currentRs2Prior.valid && cdbMessage.robIndex === currentRs2Prior.payload) {
-        meta.rs2.priorInstruction.valid := False
-        r2w := False
-        pipeline.serviceOption[SpeculationService] foreach { spec =>
-          when(spec.isSpeculativeMD(cdbMessage.metadata)) {
-            meta.loadSpeculation := True
-            lsw := True
-          }
-        }
-        regs.setReg(pipeline.data.RS2_DATA, cdbMessage.writeValue)
-      }
-
       when(!r1w && !r2w && !softFlush) {
         // This is the only place where state is written directly (instead of
         // via stateNext). This ensures that we have priority over whatever
@@ -190,6 +201,7 @@ class ReservationStation(
       }
     }
   }
+
 
   def build(): Unit = {
     meta.build()
@@ -263,14 +275,13 @@ class ReservationStation(
         dispatchStream.payload.registerMap.element(register) := exeStage.output(register)
       }
 
-      pipeline.serviceOption[SpeculationService] foreach { spec =>
-        {
-          spec.speculationDependency(cdbStream.payload.metadata) := meta.priorBranch
-          // keep control flow speculation taint if the CF speculation is resolved while still load speculating
-          spec.isSpeculativeCF(cdbStream.metadata) := spec.isSpeculativeCFOutput(exeStage) || (spec
-            .isSpeculativeCFInput(exeStage) && meta.loadSpeculation)
-          spec.isSpeculativeMD(cdbStream.metadata) := meta.loadSpeculation
-        }
+      pipeline.serviceOption[SpeculationService] foreach { spec => {
+        spec.speculationDependency(cdbStream.payload.metadata) := meta.priorBranch
+        // keep control flow speculation taint if the CF speculation is resolved while still load speculating
+        spec.isSpeculativeCF(cdbStream.metadata) := spec.isSpeculativeCFOutput(exeStage) || (spec
+          .isSpeculativeCFInput(exeStage) && meta.loadSpeculation)
+        spec.isSpeculativeMD(cdbStream.metadata) := meta.loadSpeculation
+      }
       }
 
       // if the broadcasted address-based PSF prediction turned out to be incorrect, we have to activate the CDB again
@@ -388,10 +399,10 @@ class ReservationStation(
     }
 
     def dependencySetup(
-        metaRs: RegisterSource,
-        rsData: Flow[RsData],
-        regData: PipelineData[UInt]
-    ): Unit = {
+                         metaRs: RegisterSource,
+                         rsData: Flow[RsData],
+                         regData: PipelineData[UInt]
+                       ): Unit = {
       when(rsData.valid) {
         when(rsData.payload.updatingInstructionFound) {
           when(rsData.payload.updatingInstructionFinished) {

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/ReservationStation.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/ReservationStation.scala
@@ -204,6 +204,9 @@ class ReservationStation(
 
 
   def build(): Unit = {
+
+    val lsu = pipeline.service[LsuService]
+
     meta.build()
 
     cdbWaitingNext := cdbWaiting
@@ -251,6 +254,8 @@ class ReservationStation(
         }
         cdbStream.payload.writeValue := rob.previousStoreBuffer
         cdbStream.payload.robIndex := robEntryIndex
+        lsu.psfState(cdbStream.metadata) := PsfState.PREDICTION
+
         cdbStream.valid := True
         when(cdbStream.ready) {
           broadcastedPsfPrediction := True
@@ -265,13 +270,10 @@ class ReservationStation(
       cdbStream.payload.robIndex := robEntryIndex
       dispatchStream.payload.robIndex := robEntryIndex
 
-      val lsu = pipeline.service[LsuService]
-
       val isLoad = lsu.operationOutput(exeStage) === LsuOperationType.LOAD
-
       val broadcastedIncorrectPsfPrediction = Bool()
 
-      for (register <- retirementRegisters.keys.filter(e => e != lsu.psfMisspeculationRegister)) {
+      for (register <- retirementRegisters.keys.filter(e => e != lsu.psfStateRegister)) {
         dispatchStream.payload.registerMap.element(register) := exeStage.output(register)
       }
 
@@ -289,8 +291,14 @@ class ReservationStation(
         broadcastedIncorrectPsfPrediction := isLoad && lsu.address(
           exeStage
         ) =/= psfPredictedAddress && broadcastedPsfPrediction && !noPsfPrediction
-        lsu.psfMisspeculation(cdbStream.metadata) := broadcastedIncorrectPsfPrediction
-        lsu.psfMisspeculation(dispatchStream.registerMap) := broadcastedIncorrectPsfPrediction
+
+        lsu.psfState(cdbStream.metadata) := PsfState.NONE
+        lsu.psfState(dispatchStream.registerMap) := PsfState.NONE
+
+        when(broadcastedIncorrectPsfPrediction) {
+          lsu.psfState(cdbStream.metadata) := PsfState.WARNING
+          lsu.psfState(dispatchStream.registerMap) := PsfState.MISS
+        }
       }
 
       pipeline.serviceOption[SpeculationService] match {

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/Scheduler.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/Scheduler.scala
@@ -81,6 +81,8 @@ class Scheduler() extends Plugin[DynamicPipeline] with IssueService {
       val dispatchBus = new DispatchBus(reservationStations, rob, dispatcher, registerBundle)
       dispatchBus.build()
 
+      rob.processFlushes()
+
       dispatcher.rdbStream >> robDataBus.inputs(0)
 
       for ((rs, index) <- reservationStations.zipWithIndex) {

--- a/src/main/scala/riscv/plugins/scheduling/dynamic/Scheduler.scala
+++ b/src/main/scala/riscv/plugins/scheduling/dynamic/Scheduler.scala
@@ -22,8 +22,8 @@ class Scheduler() extends Plugin[DynamicPipeline] with IssueService {
 
       private val lsu = pipeline.service[LsuService]
       lsu.addPsfAddress(cdbBMetaData)
-      lsu.addPsfMisspeculation(cdbBMetaData)
-      lsu.addPsfMisspeculation(registerBundle)
+      lsu.addPsfState(cdbBMetaData)
+      lsu.addPsfState(registerBundle)
       lsu.addPsfAddress(registerBundle)
 
       pipeline.serviceOption[SpeculationService] foreach { spec =>


### PR DESCRIPTION
# Superscalar PSF and ROB Flush system (Draft)
While working on adding superscalar execution for my thesis, I encountered several timing and race condition challenges within the pipeline control structures. This PR makes the Reorder Buffer (ROB) flush mechanism and Predictive Store Forwarding (PSF) system more robust, modular, and easier to parallelize for future superscalar expansion.

## Flush system

In the current system, the ROB can perform soft and hard flushes. Flush sources rely on the `softFlush` function and manual arbitration logic to decide when and how a flush happens.

This PR adds the `FlushPort` class and `processFlushes` method. A `FlushPort` can be used to request flushes and attach software-like callbacks that execute only when a specific flush type is granted. The `processFlushes` method arbitrates between multiple parallel requests to select the oldest instruction. This simplifies existing component logic because event handlers like `onCdbMessage` and `onRdbMessage` no longer need to manually arbitrate or coordinate flush priorities amongst themselves. It also significantly streamlines adding superscalar execution later.

## PSF

In the previous implementation, Predictive Store Forwarding (PSF) relied on a single `psfMisspeculation` boolean flag to track errors. This caused race conditions because the ROB could not differentiate between an early address mismatch detection (where the true load data has not yet arrived from memory) and the final data completion.

This PR replaces the single boolean flag with a 4-state `PsfState` enum (`NONE`, `PREDICTION`, `WARNING`, `MISS`) carried within the pipeline data. This streamlines the control logic across the ROB. The PSF system follows the same general sequence, but with several key improvements:

* **Speculative Broadcasts (`PREDICTION`):** When a Reservation Station (RS) is waiting for a load address, it broadcasts an early value prediction on the Common Data Bus (CDB) with state `PREDICTION`. Dependent RS units ignore the state metadata and start executing immediately. The ROB processes this state solely by incrementing a tracking counter (`psfPredictions`), leaving instruction validity untouched.
* **Early Flush Signal (`WARNING`):** Once the RS computes the actual address and detects a mismatch against the broadcasted prediction, it emits a fast CDB message with state `WARNING`. The ROB reacts by immediately requesting a pipeline flush via its `FlushPort` to squash speculative younger instructions. Crucially, the ROB **does not** mark the entry as valid (`cdbUpdated` remains false), preventing premature retirement before the actual memory read finishes.
* **Authoritative Data Completion (`MISS`):** When the Load Manager completes the actual memory access, it broadcasts the true data on the CDB (and RDB) with state `MISS`. Upon receipt, the ROB captures the correct destination register value, sets `cdbUpdated := True`, and issues a fallback flush request. Because a mispredicted load emits both an early `WARNING` and a subsequent `MISS`, the new `processFlushes` arbitration logic evaluates active reset triggers and safely suppresses duplicate flush requests arriving for the same instruction index.

## Evaluation

### Instructions Per Clock Cycle (IPC)

The IPC remained identical across all configurations. The same holds true for data and instruction cache miss rates, as well as branch prediction accuracy.

<img width="2971" height="1494" alt="image" src="https://github.com/user-attachments/assets/775620a3-7a53-4936-b1bf-51ccd0dfe7dc" />

### Flushes

A primary observation is that there are significantly fewer hard flushes. This occurs because the `processFlushes` logic can override the existing `softResetTrigger` if a newly requested flush belongs to an older instruction. Previously, this scenario would have forced a hard flush fallback.

<img width="2534" height="1466" alt="hard_flush_changes" src="https://github.com/user-attachments/assets/753f7ba6-b9bc-464b-8d3f-89461450d7b8" />

Consequently, the number of soft flushes has increased.

<img width="2534" height="1466" alt="soft_flush_changes" src="https://github.com/user-attachments/assets/a382373e-1f8b-4261-b77a-19a01d9fb40b" />

The total number of flushes (`soft + hard`) remained roughly constant across the benchmarks.

<img width="2534" height="1466" alt="total_flush_changes" src="https://github.com/user-attachments/assets/bb0b490a-6806-40ae-90bd-301bf0ab244e" />

### PSF

The number of recorded PSF mispredictions per program improved with the new flush system. This is likely the result of changes in the misprediction counting under the unified flush arbitration.

<img width="2969" height="1494" alt="psf_mispredictions" src="https://github.com/user-attachments/assets/6f0f69e4-719c-41d2-bf62-a41c3b2ba676" />

The total number of actual flushes remained mostly unchanged compared to the configuration with only the new flush system.

<img width="2534" height="1466" alt="total_flush_changes_psf" src="https://github.com/user-attachments/assets/b08acfe7-8258-4ea7-95c0-cce79533ec70" />